### PR TITLE
47 resolve ondelete cascade for registration

### DIFF
--- a/app/models/event.py
+++ b/app/models/event.py
@@ -1,6 +1,7 @@
-from sqlmodel import SQLModel, Field
-from typing import Annotated
+from sqlmodel import SQLModel, Field, Relationship
 from datetime import datetime
+from datetime import datetime
+from app.models.registration import Registration
 
 class EventBase(SQLModel):
     """
@@ -15,7 +16,14 @@ class Event(EventBase, table=True):
     """
     Modello di evento che estende EventBase e rappresenta una tabella nel database.
     """
-    id: int = Field(default=None, primary_key=True) # Campo ID che funge da chiave primaria, con valore predefinito None 
+    id: int = Field(default=None, primary_key=True) # Campo ID che funge da chiave primaria, con valore predefinito None
+    registrations: list["Registration"] = Relationship(
+        back_populates="event",
+        sa_relationship_kwargs=
+        {
+            "cascade": "all,delete,delete-orphan"
+        }
+    )
 
 class EventCreate(EventBase): # Modello per la creazione di un nuovo evento
     """

--- a/app/models/registration.py
+++ b/app/models/registration.py
@@ -1,18 +1,56 @@
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy import Column, ForeignKey, String, Integer
+from typing import TYPE_CHECKING
 
-class Registration(SQLModel, table=True):
-    username: str = Field(primary_key=True, foreign_key="user.username", ondelete="CASCADE")
-    event_id: int = Field(primary_key=True, foreign_key="event.id", ondelete="CASCADE")
+if TYPE_CHECKING: # per evitare import ciclici con User e Event
+    # Importa User ed Event solo se il tipo di controllo è attivo, per evitare cicli di importazione
+    from app.models.user import User
+    from app.models.event import Event
 
-class RegistrationPublic(Registration):
+class RegistrationBase(SQLModel):
+    """
+    Modello base per la registrazione, definisce i campi comuni.
+    """
+    username: str
+    event_id: int
+
+class Registration(RegistrationBase, table=True):
+    """
+    Modello di registrazione che estende RegistrationBase e rappresenta una tabella nel database.
+    """
+    username: str = Field(
+        sa_column=Column(
+            "username", String,
+            ForeignKey(
+                "user.username",
+                ondelete="CASCADE" # Imposta la cancellazione a cascata
+            ),
+            primary_key=True
+        )
+    )
+    event_id: int = Field(
+        sa_column=Column(
+            "event_id", Integer,
+            ForeignKey(
+                "event.id",
+                ondelete="CASCADE" # Imposta la cancellazione a cascata
+            ),
+            primary_key=True
+        )
+    )
+
+    user: "User" = Relationship(back_populates="registrations") # Relazione con il modello User
+    event: "Event" = Relationship(back_populates="registrations") # Relazione con il modello Event
+
+class RegistrationPublic(RegistrationBase):
     """
     Modello utilizzato per restituire tutti i dati delle registrazioni nelle risposte API.
-    Estende Registration e include i campi necessari per la visualizzazione pubblica.
+    Estende RegistrationBase e include i campi necessari per la visualizzazione pubblica.
     """
-    pass
+    pass # Non include ulteriori campi, poiché eredita tutto da RegistrationBase
 
-class RegistrationCreate(Registration):
+class RegistrationCreate(RegistrationBase):
     """
-    Modello per la creazione di una nuova registrazione, estende Registration senza ID.
+    Modello per la creazione di una nuova registrazione, estende RegistrationBase.
     """
-    pass  # Non ha bisogno di ulteriori campi, poiché eredita tutto da Registration
+    pass  # Non ha bisogno di ulteriori campi, poiché eredita tutto da RegistrationBase

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,5 @@
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+from app.models.registration import Registration
 
 class BaseUser(SQLModel):
     """
@@ -13,6 +14,13 @@ class User(BaseUser, table=True):
     Modello di utente che estende BaseUser e rappresenta una tabella nel database.
     """
     username: str = Field(primary_key=True)
+    registrations: list["Registration"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs=
+        {
+            "cascade": "all, delete-orphan"
+        }
+    )
 
 class UserPublic(BaseUser):
     """

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -81,9 +81,14 @@ def delete_all_events(session: SessionDep):
     """
     Elimina tutti gli eventi.
     """
-    statement = delete(Event)
-    session.exec(statement)
-    session.commit()
+    # statement = delete(Event) # Non funziona il cascading delete.
+    # siccome singolarmente funziona, allora lo faccio uno per uno.
+    statement = select(Event) # Seleziona tutti gli eventi
+    events = session.exec(statement).all() # Esegui la query per ottenere tutti gli eventi in una lista
+    for event in events: # per ogni evento nella lista
+        session.delete(event) # Elimina l'evento dalla sessione
+    # session.exec(statement)
+    session.commit() # Commit le modifiche al database
     return {"detail": "Tutti gli eventi sono stati eliminati"}
 
 @router.delete("/{id}")

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -49,7 +49,6 @@ def add_user(
     session.commit()
     return "User aggiunto con successo."
 
-
 @router.delete("/")
 def delete_all_users(
     session: SessionDep
@@ -57,9 +56,14 @@ def delete_all_users(
     """
     Cancella tutti gli utenti.
     """
-    statement = delete(User)
-    session.exec(statement)
-    session.commit()
+    # statement = delete(User) # Non funziona il cascading delete.
+    # siccome singolarmente funziona, allora lo faccio uno per uno.
+    statement = select(User) # Seleziona tutti gli utenti
+    users = session.exec(statement).all() # Recupera tutti gli utenti
+    for user in users: # Itera su ogni utente
+        session.delete(user) # Elimina l'utente corrente
+    # session.exec(statement)
+    session.commit() # Commit delle modifiche
     return "Tutti gli utenti sono stati cancellati."
 
 @router.delete("/{username}")


### PR DESCRIPTION
Risolto il problema di eliminazione delle tuple in cascata.

Sia singolarmente che eliminando tutti gli elementi. Purtroppo l'eliminazione dell'intera tabella non attiva la cascata, ma siccome funziona singolarmente allora ho messo un ciclo di delete delle singole tuple.

Controllate se funziona tutto di nuovo, non so se vogliamo rendere la modifica attiva, ormai l'abbiamo consegnato.

Ho aggiunto anche il modello base di registration.

Le classi stavano ereditando da Registration con table=true e stava dando problemi il db.
